### PR TITLE
Add deterministic sampler

### DIFF
--- a/Honeycomb.OpenTelemetry.sln
+++ b/Honeycomb.OpenTelemetry.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeycomb.OpenTelemetry", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sample", "sample\sample.csproj", "{203485D4-49A0-4FDC-BD94-4D4614BA525A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5F0932EB-818C-4810-9335-2C79E3424694}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeycomb.Samplers.Test", "test\Honeycomb.Samplers.Test\Honeycomb.Samplers.Test.csproj", "{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,8 +50,21 @@ Global
 		{203485D4-49A0-4FDC-BD94-4D4614BA525A}.Release|x64.Build.0 = Release|Any CPU
 		{203485D4-49A0-4FDC-BD94-4D4614BA525A}.Release|x86.ActiveCfg = Release|Any CPU
 		{203485D4-49A0-4FDC-BD94-4D4614BA525A}.Release|x86.Build.0 = Release|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Debug|x64.Build.0 = Debug|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Debug|x86.Build.0 = Debug|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Release|x64.ActiveCfg = Release|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Release|x64.Build.0 = Release|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Release|x86.ActiveCfg = Release|Any CPU
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{C2F8CF20-D78C-4A8D-92F3-DEA8CEB258CB} = {553833DF-9FCA-411A-933D-0648B0DFDF71}
+		{07676966-A3CB-4CB6-8FEA-61C79DEB5E63} = {5F0932EB-818C-4810-9335-2C79E3424694}
 	EndGlobalSection
 EndGlobal

--- a/src/Honeycomb.Samplers/DeterministicSampler.cs
+++ b/src/Honeycomb.Samplers/DeterministicSampler.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using OpenTelemetry.Trace;
+
+namespace Honeycomb.Samplers
+{
+    public class DeterministicSampler : Sampler
+    {
+        private const string DescriptionFormat = "DeterministicSampler({0})";
+        private const string SampleRateAttributeName = "sampleRate";
+        private const string Hphen = "-";
+        private const int Zero = 0;
+        private const int Four = 4;
+        private const int One = 1;
+        private const int Base16 = 16;
+        private int sampleRate;
+        private long upperBound;
+
+        public DeterministicSampler(int sampleRate)
+        {
+            if (sampleRate < Zero)
+            {
+                throw new ArgumentOutOfRangeException("Sample rate must not be negative.");
+            }
+
+            this.sampleRate = sampleRate;
+            this.Description = string.Format(DescriptionFormat, this.sampleRate.ToString(CultureInfo.InvariantCulture));
+            this.upperBound = sampleRate == Zero ? Zero : uint.MaxValue / sampleRate;
+        }
+
+        public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+        {
+            if (sampleRate == One)
+            {
+                return CreateResult(SamplingDecision.RecordAndSample, One);
+            }
+            if (sampleRate == One)
+            {
+                return CreateResult(SamplingDecision.Drop, Zero);
+            }
+
+            using (var hash = SHA1.Create())
+            {
+                var bytes = Encoding.UTF8.GetBytes(samplingParameters.TraceId.ToString());
+                var digest = hash.ComputeHash(bytes);
+                var determinant = Convert.ToUInt32(BitConverter.ToString(digest, Zero, Four).Replace(Hphen, string.Empty).ToLower(), Base16);
+                var decision = determinant <= upperBound
+                    ? SamplingDecision.RecordAndSample
+                    : SamplingDecision.Drop;
+
+                return CreateResult(
+                    decision,
+                    decision == SamplingDecision.RecordAndSample ? sampleRate : Zero
+                );
+            }
+        }
+
+        private static SamplingResult CreateResult(SamplingDecision decision, int sampleRate)
+        {
+            return new SamplingResult(
+                decision,
+                new Dictionary<string, object>{ {SampleRateAttributeName, sampleRate} }
+            );
+        }
+    }
+}

--- a/src/Honeycomb.Samplers/DeterministicSampler.cs
+++ b/src/Honeycomb.Samplers/DeterministicSampler.cs
@@ -11,7 +11,7 @@ namespace Honeycomb.Samplers
     {
         private const string DescriptionFormat = "DeterministicSampler({0})";
         private const string SampleRateAttributeName = "sampleRate";
-        private const string Hphen = "-";
+        private const string Hyphen = "-";
         private const int Zero = 0;
         private const int Four = 4;
         private const int One = 1;
@@ -45,7 +45,7 @@ namespace Honeycomb.Samplers
 
             var bytes = Encoding.UTF8.GetBytes(samplingParameters.TraceId.ToString());
             var hash = sha1.ComputeHash(bytes);
-            var determinant = Convert.ToUInt32(BitConverter.ToString(hash, Zero, Four).Replace(Hphen, string.Empty).ToLower(), Base16);
+            var determinant = Convert.ToUInt32(BitConverter.ToString(hash, Zero, Four).Replace(Hyphen, string.Empty).ToLower(), Base16);
             var decision = determinant <= upperBound
                 ? SamplingDecision.RecordAndSample
                 : SamplingDecision.Drop;

--- a/src/Honeycomb.Samplers/DeterministicSampler.cs
+++ b/src/Honeycomb.Samplers/DeterministicSampler.cs
@@ -38,7 +38,7 @@ namespace Honeycomb.Samplers
             {
                 return CreateResult(SamplingDecision.RecordAndSample, One);
             }
-            if (sampleRate == One)
+            if (sampleRate == Zero)
             {
                 return CreateResult(SamplingDecision.Drop, Zero);
             }

--- a/src/Honeycomb.Samplers/DeterministicSampler.cs
+++ b/src/Honeycomb.Samplers/DeterministicSampler.cs
@@ -22,6 +22,8 @@ namespace Honeycomb.Samplers
         private const int IndexFour = 4;
         private const int Base16 = 16;
         private readonly SHA1 sha1 = SHA1.Create();
+        private static SamplingResult AlwaysSampleResult = CreateResult(SamplingDecision.RecordAndSample, AlwaysSample);
+        private static SamplingResult NeverSampleResult = CreateResult(SamplingDecision.Drop, NeverSample);
 
         /// <summary>
         /// The sample rate for spans to be exported. Express as 1/X where x is the sample rate value.
@@ -53,11 +55,11 @@ namespace Honeycomb.Samplers
         {
             if (SampleRate == AlwaysSample)
             {
-                return CreateResult(SamplingDecision.RecordAndSample, AlwaysSample);
+                return AlwaysSampleResult;
             }
             if (SampleRate == NeverSample)
             {
-                return CreateResult(SamplingDecision.Drop, NeverSample);
+                return NeverSampleResult;
             }
 
             var bytes = Encoding.UTF8.GetBytes(samplingParameters.TraceId.ToString());

--- a/src/Honeycomb.Samplers/DeterministicSampler.cs
+++ b/src/Honeycomb.Samplers/DeterministicSampler.cs
@@ -7,6 +7,10 @@ using OpenTelemetry.Trace;
 
 namespace Honeycomb.Samplers
 {
+    /// <summary>
+    /// An OpenTelemetry Sampler implementation that produces deterministic results that is compatible with
+    /// Honeycomb Beelines.
+    /// </summary>
     public class DeterministicSampler : Sampler, IDisposable
     {
         private const string DescriptionFormat = "DeterministicSampler({0})";
@@ -19,9 +23,19 @@ namespace Honeycomb.Samplers
         private const int Base16 = 16;
         private readonly SHA1 sha1 = SHA1.Create();
 
+        /// <summary>
+        /// The sample rate for spans to be exported. Express as 1/X where x is the sample rate value.
+        /// </summary>
         public int SampleRate { get; private set; }
+
+        /// <summary>
+        /// The calculated upper bound the sample rate must be equal to or below to be sampled.
+        /// </summary>
         public long UpperBound { get; private set; }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="DeterministicSampler"/>.
+        /// </summary>
         public DeterministicSampler(int sampleRate)
         {
             if (sampleRate < NeverSample)
@@ -34,6 +48,7 @@ namespace Honeycomb.Samplers
             this.UpperBound = sampleRate == NeverSample ? NeverSample : uint.MaxValue / sampleRate;
         }
 
+        /// <inheritdoc/>
         public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
         {
             if (SampleRate == AlwaysSample)

--- a/src/Honeycomb.Samplers/Honeycomb.Samplers.csproj
+++ b/src/Honeycomb.Samplers/Honeycomb.Samplers.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/test/Honeycomb.Samplers.Test/DeterministicSamplerTests.cs
+++ b/test/Honeycomb.Samplers.Test/DeterministicSamplerTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
+using OpenTelemetry.Trace;
+
+namespace Honeycomb.Samplers.Test
+{
+    public class DeterministicSamplerTests
+    {
+        [Fact]
+        public void Negative_samplerate_throws_exception()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DeterministicSampler(-1));
+        }
+
+        [Fact]
+        public void Description_includes_sample_rate()
+        {
+            Assert.Equal("DeterministicSampler(10)", new DeterministicSampler(10).Description);
+        }
+
+        [Theory]
+        [InlineData("6cbf4d3e8a69f640a6db7d0ca66861c7", true)]
+        [InlineData("31cbd4a6e54d33439ad887d2d90dce9e", false)]
+        public void Sampler_works_with_given_sample_point(string traceId, bool isSampled)
+        {
+            SamplingResult result;
+            var sampler = new DeterministicSampler(17); // sample 1 in 17
+
+            result = sampler.ShouldSample(new SamplingParameters(new ActivityContext(), ActivityTraceId.CreateFromString(traceId), "span_name", ActivityKind.Server));
+            Assert.Equal(isSampled ? SamplingDecision.RecordAndSample : SamplingDecision.Drop, result.Decision);
+            Assert.Equal(new Dictionary<string, object> {{"sampleRate", isSampled ? 17 : 0 }}, result.Attributes);
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(10)]
+        [InlineData(20)]
+        public void Check_sample_rates_are_within_expected_bounds(int sampleRate)
+        {
+            const double marginOfError = 0.05;
+            const int sampleSize = 50000;
+            var sampler = new DeterministicSampler(sampleRate);
+            var count = 0;
+            for (int i = 0; i < sampleSize; i++)
+            {
+                var result = sampler.ShouldSample(new SamplingParameters(new ActivityContext(), ActivityTraceId.CreateRandom(), "span_name", ActivityKind.Server));
+                if (result.Decision == SamplingDecision.RecordAndSample)
+                {
+                    count++;
+                }
+            }
+
+            var expectedSampleCount = sampleSize * (1 / (double) sampleRate);
+            var variance = expectedSampleCount * marginOfError;
+            Assert.InRange(count, expectedSampleCount - variance, expectedSampleCount + variance);
+        }
+
+        [Fact]
+        public void Sample_rate_of_1_samples_all()
+        {
+            var sampler = new DeterministicSampler(1);
+            var count = 0;
+            for (int i = 0; i < 50000; i++)
+            {
+                var result = sampler.ShouldSample(new SamplingParameters(new ActivityContext(), ActivityTraceId.CreateRandom(), "span_name", ActivityKind.Server));
+                if (result.Decision == SamplingDecision.RecordAndSample)
+                {
+                    count++;
+                }
+            }
+
+            Assert.Equal(50000, count);
+        }
+
+        [Fact]
+        public void Sample_rate_of_0_samples_none()
+        {
+            var sampler = new DeterministicSampler(0);
+            var count = 0;
+            for (int i = 0; i < 50000; i++)
+            {
+                var result = sampler.ShouldSample(new SamplingParameters(new ActivityContext(), ActivityTraceId.CreateRandom(), "span_name", ActivityKind.Server));
+                if (result.Decision == SamplingDecision.RecordAndSample)
+                {
+                    count++;
+                }
+            }
+
+            Assert.Equal(0, count);
+        }
+
+        [Fact]
+        public void Verify_samplers_give_consistent_results()
+        {
+            var samplerA = new DeterministicSampler(3);
+            var samplerb = new DeterministicSampler(3);
+            var samplingParams = new SamplingParameters(new ActivityContext(), ActivityTraceId.CreateRandom(), "span_name", ActivityKind.Server);
+            var firstAnswer = samplerA.ShouldSample(samplingParams);
+
+            for (int i = 0; i < 25; i++)
+            {
+                var resultA = samplerA.ShouldSample(samplingParams);
+                Assert.Equal(firstAnswer.Decision, resultA.Decision);
+
+                var resultB = samplerb.ShouldSample(samplingParams);
+                Assert.Equal(firstAnswer.Decision, resultB.Decision);
+            }
+        }
+    }
+}

--- a/test/Honeycomb.Samplers.Test/Honeycomb.Samplers.Test.csproj
+++ b/test/Honeycomb.Samplers.Test/Honeycomb.Samplers.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honeycomb.Samplers\Honeycomb.Samplers.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds a deterministic sampler that can be used with the OTel SDK as a span processor. This matches the same behaviour seen in the Honeycomb Beelines and applies the same sampling algorithm so it can be used consistently in a mixed environment.

NOTE: This depends on #4 that updates the OTel SDK to v0.7.0-beta.1