### PR TITLE
Set configured resource attributes during export

### DIFF
--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -36,7 +36,7 @@ namespace sample
                 builder.UseHoneycomb(sp)
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .SetResource(Resources.CreateServiceResource("ny-service-name"));
+                    .SetResource(Resources.CreateServiceResource("my-service-name"));
             });
         }
 

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -7,6 +7,7 @@ using Honeycomb.OpenTelemetry;
 using Honeycomb.Models;
 using Honeycomb;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
 
 namespace sample
 {
@@ -34,7 +35,8 @@ namespace sample
             services.AddOpenTelemetryTracing((sp, builder) => {
                 builder.UseHoneycomb(sp)
                     .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation();
+                    .AddHttpClientInstrumentation()
+                    .SetResource(Resources.CreateServiceResource("ny-service-name"));
             });
         }
 

--- a/src/Honeycomb.OpenTelemetry/HoneycombExporter.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombExporter.cs
@@ -4,6 +4,7 @@ using Honeycomb.Models;
 using Microsoft.Extensions.Options;
 using System;
 using OpenTelemetry;
+using OpenTelemetry.Trace;
 using System.Diagnostics;
 
 namespace Honeycomb.OpenTelemetry
@@ -66,6 +67,20 @@ namespace Honeycomb.OpenTelemetry
             foreach (var label in activity.Tags)
             {
                 ev.Data.Add(label.Key, label.Value.ToString());
+            }
+
+            var resource = activity.GetResource();
+            foreach (var attribute in resource.Attributes)
+            {
+                // map service.name to service_name
+                if (attribute.Key == "service.name")
+                {
+                    ev.Data["service_name"] = attribute.Value;
+                }
+                else
+                {
+                    ev.Data.Add(attribute.Key, attribute.Value);
+                }
             }
 
             foreach (var message in activity.Events)


### PR DESCRIPTION
The OpenTelemetry SDK can have resource attributes configured during setup, these should be exported as tags too. This includes setting a consistent process / application name.

Fixes #5.